### PR TITLE
YenDrive: prevent NaN output when gain parameter is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [UNRELEASED]
 - Changed UI rendering to use OpenGL by default on Windows/Linux, unless OpenGL 2.0+ is not available on the host system.
+- Fixed YenDrive giving NaN output when Gain parameter set to zero.
 
 ## [1.0.0] 2022-03-11
 - Initial release.

--- a/src/processors/drive/zen_drive/ZenDriveWDF.h
+++ b/src/processors/drive/zen_drive/ZenDriveWDF.h
@@ -21,6 +21,7 @@ public:
 
     void setParameters (float voiceParam, float gainParam, bool force = false)
     {
+        gainParam = jmax (gainParam, 0.001f); // protect from R9 going to zero
         if (force)
         {
             voiceSmooth.setCurrentAndTargetValue (voiceParam);


### PR DESCRIPTION
Fixes #127 