### PR TITLE
UI redrawing optimizations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Added "High-Quality" options for RangeBooster and MuffDrive modules.
 - Added new factory presets.
 - Added UI control to replace a wire with a 1-input/1-output module.
+- Added UI control to replace a 1-input/1-output module with a wire.
 - Added UI size to the saved plugin state.
 - Improved neural network-based modules performance and sound quality at different sample rates.
 - Improved UI rendering performance.

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -65,7 +65,6 @@ target_compile_definitions(juce_plugin_modules
         JucePlugin_VersionString="${CMAKE_PROJECT_VERSION}"
         JucePlugin_Name="${CMAKE_PROJECT_NAME}"
         JUCE_MODAL_LOOPS_PERMITTED=1
-        JUCE_ENABLE_REPAINT_DEBUGGING=1
     INTERFACE
         $<TARGET_PROPERTY:juce_plugin_modules,COMPILE_DEFINITIONS>
 )

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -65,6 +65,7 @@ target_compile_definitions(juce_plugin_modules
         JucePlugin_VersionString="${CMAKE_PROJECT_VERSION}"
         JucePlugin_Name="${CMAKE_PROJECT_NAME}"
         JUCE_MODAL_LOOPS_PERMITTED=1
+        JUCE_ENABLE_REPAINT_DEBUGGING=1
     INTERFACE
         $<TARGET_PROPERTY:juce_plugin_modules,COMPILE_DEFINITIONS>
 )

--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -102,7 +102,7 @@ void Cable::repaintIfNeeded (bool force)
 
         auto cableBounds = cablePath.getBounds().toNearestInt();
         cableBounds.setY (cableBounds.getY() - roundToInt (std::ceil (2.0f * minCableThickness)));
-        cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (4.0f * minCableThickness) ));
+        cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (4.0f * minCableThickness)));
 
         MessageManager::callAsync ([&, cableBounds]
                                    { repaint (cableBounds); });

--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -101,8 +101,8 @@ void Cable::repaintIfNeeded (bool force)
         cablePath = std::move (createdPath);
 
         auto cableBounds = cablePath.getBounds().toNearestInt();
-        cableBounds.setY (cableBounds.getY() - roundToInt (std::ceil (2.0f * minCableThickness)));
-        cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (4.0f * minCableThickness)));
+        cableBounds.setY (cableBounds.getY() - roundToInt (std::ceil (4.0f * minCableThickness)));
+        cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (8.0f * minCableThickness)));
 
         MessageManager::callAsync ([&, cableBounds]
                                    { repaint (cableBounds); });

--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -104,8 +104,12 @@ void Cable::repaintIfNeeded (bool force)
         cableBounds.setY (cableBounds.getY() - roundToInt (std::ceil (4.0f * minCableThickness)));
         cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (8.0f * minCableThickness)));
 
-        MessageManager::callAsync ([&, cableBounds]
-                                   { repaint (cableBounds); });
+        MessageManager::callAsync (
+            [safeComp = Component::SafePointer (this), cableBounds]
+            {
+                if (auto* comp = safeComp.getComponent())
+                    comp->repaint (cableBounds);
+            });
     };
 
     if (force || connectionInfo.endProc == nullptr)

--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -1,6 +1,5 @@
 #include "Cable.h"
 #include "../BoardComponent.h"
-#include "CableDrawingHelpers.h"
 #include "CableViewConnectionHelper.h"
 #include "CableViewPortLocationHelper.h"
 
@@ -24,7 +23,7 @@ bool Cable::hitTest (int x, int y)
     for (int i = 1; i <= numPointsInPath; ++i)
     {
         auto pointOnPath = bezier.getPointOnCubicBezier ((float) i / (float) numPointsInPath);
-        if (clickedP.getDistanceFrom (pointOnPath) < cablethickness)
+        if (clickedP.getDistanceFrom (pointOnPath) < cableThickness)
         {
             return true;
         }
@@ -33,16 +32,55 @@ bool Cable::hitTest (int x, int y)
     return false;
 }
 
-float Cable::getCableThickness()
+void Cable::updateStartPoint (bool repaintIfMoved)
 {
-    levelDB = jlimit (floorDB, 0.0f, levelDB);
-    auto levelMult = std::pow (jmap (levelDB, floorDB, 0.0f, 0.0f, 1.0f), 0.9f);
-    return cableThickness * (1.0f + 0.9f * levelMult);
+    auto* startEditor = board->findEditorForProcessor (connectionInfo.startProc);
+    jassert (startEditor != nullptr);
+
+    scaleFactor = board->getScaleFactor();
+    startColour = startEditor->getColour();
+    cableThickness = getCableThickness();
+
+    const auto newPortLocation = CableViewPortLocationHelper::getPortLocation ({ startEditor, connectionInfo.startPort, false }).toFloat();
+    if (startPoint.load() != newPortLocation)
+    {
+        startPoint.store (newPortLocation);
+        if (repaintIfMoved)
+            repaintIfNeeded (true);
+    }
 }
 
-auto Cable::createCablePath (juce::Point<float> start, juce::Point<float> end)
+void Cable::updateEndPoint (bool repaintIfMoved)
 {
-    const auto pointOff = portOffset + scaleFactor;
+    if (connectionInfo.endProc != nullptr)
+    {
+        auto* endEditor = board->findEditorForProcessor (connectionInfo.endProc);
+        endColour = endEditor->getColour();
+
+        const auto newPortLocation = CableViewPortLocationHelper::getPortLocation ({ endEditor, connectionInfo.endPort, true }).toFloat();
+        if (endPoint.load() != newPortLocation)
+        {
+            endPoint.store (newPortLocation);
+            if (repaintIfMoved)
+                repaintIfNeeded (true);
+        }
+    }
+    else if (cableView.cableBeingDragged())
+    {
+        endColour = startColour;
+        endPoint = cableView.getCableMousePosition();
+    }
+    else
+    {
+        // when the cable has just been created, we don't have the mouse drag
+        // source yet, so let's just set the end point equal to the start point.
+        endPoint.store (startPoint);
+    }
+}
+
+Path Cable::createCablePath (juce::Point<float> start, juce::Point<float> end, float sf)
+{
+    const auto pointOff = portOffset + sf;
     bezier = CubicBezier (start, start.translated (pointOff, 0.0f), end.translated (-pointOff, 0.0f), end);
     numPointsInPath = (int) start.getDistanceFrom (end) + 1;
     Path bezierPath;
@@ -54,17 +92,58 @@ auto Cable::createCablePath (juce::Point<float> start, juce::Point<float> end)
     return std::move (bezierPath);
 }
 
+void Cable::repaintIfNeeded (bool force)
+{
+    const auto regeneratePath = [this]
+    {
+        auto createdPath = createCablePath (startPoint, endPoint, scaleFactor);
+        ScopedLock sl (pathCrit);
+        cablePath = std::move (createdPath);
+
+        auto cableBounds = cablePath.getBounds().toNearestInt();
+        cableBounds.setY (cableBounds.getY() - roundToInt (std::ceil (2.0f * minCableThickness)));
+        cableBounds.setHeight (cableBounds.getHeight() + roundToInt (std::ceil (4.0f * minCableThickness) ));
+
+        MessageManager::callAsync ([&, cableBounds]
+                                   { repaint (cableBounds); });
+    };
+
+    if (force || connectionInfo.endProc == nullptr)
+    {
+        regeneratePath();
+        return;
+    }
+
+    if (connectionInfo.endProc != nullptr)
+    {
+        auto updatedLevelDB = jlimit (floorDB, 0.0f, connectionInfo.endProc->getInputLevelDB (connectionInfo.endPort));
+        auto levelDifference = std::abs (updatedLevelDB - levelDB);
+        if (std::abs (levelDifference) > 2.0f && levelRange.contains (updatedLevelDB) && levelRange.contains (levelDB))
+        {
+            levelDB = updatedLevelDB;
+            regeneratePath();
+        }
+    }
+}
+
+float Cable::getCableThickness() const
+{
+    auto levelMult = std::pow (jmap (levelDB, floorDB, 0.0f, 0.0f, 1.0f), 0.9f);
+    return minCableThickness * (1.0f + 0.9f * levelMult);
+}
+
 void Cable::drawCableShadow (Graphics& g, float thickness)
 {
+    ScopedLock sl (pathCrit);
     auto cableShadow = Path (cablePath);
     cableShadow.applyTransform (AffineTransform::translation (0.0f, thickness * 0.6f));
     g.setColour (Colours::black.withAlpha (0.3f));
-    g.strokePath (cableShadow, PathStrokeType (cableThickness, PathStrokeType::JointStyle::curved));
+    g.strokePath (cableShadow, PathStrokeType (minCableThickness, PathStrokeType::JointStyle::curved));
 }
 
 void Cable::drawCableEndCircle (Graphics& g, juce::Point<float> centre, Colour colour) const
 {
-    auto circle = (Rectangle { cableThickness, cableThickness } * 2.4f * scaleFactor).withCentre (centre);
+    auto circle = (Rectangle { minCableThickness, minCableThickness } * 2.4f * scaleFactor.load()).withCentre (centre);
     g.setColour (colour);
     g.fillEllipse (circle);
 
@@ -74,12 +153,13 @@ void Cable::drawCableEndCircle (Graphics& g, juce::Point<float> centre, Colour c
 
 void Cable::drawCable (Graphics& g, juce::Point<float> start, juce::Point<float> end)
 {
-    cablethickness = getCableThickness();
-    cablePath = createCablePath (start, end);
-    drawCableShadow (g, cablethickness);
-
+    drawCableShadow (g, cableThickness);
     g.setGradientFill (ColourGradient { startColour, start, endColour, end, false });
-    g.strokePath (cablePath, PathStrokeType (cablethickness, PathStrokeType::JointStyle::curved));
+
+    {
+        ScopedLock sl (pathCrit);
+        g.strokePath (cablePath, PathStrokeType (cableThickness, PathStrokeType::JointStyle::curved));
+    }
 
     drawCableEndCircle (g, start, startColour);
     drawCableEndCircle (g, end, endColour);
@@ -88,27 +168,13 @@ void Cable::drawCable (Graphics& g, juce::Point<float> start, juce::Point<float>
 void Cable::paint (Graphics& g)
 {
     g.setColour (cableColour.brighter (0.1f));
-    auto* startEditor = board->findEditorForProcessor (connectionInfo.startProc);
-    jassert (startEditor != nullptr);
 
-    startPortLocation = CableViewPortLocationHelper::getPortLocation ({ startEditor, connectionInfo.startPort, false }).toFloat();
-    scaleFactor = board->getScaleFactor();
-    startColour = startEditor->getColour();
+    drawCable (g, startPoint, endPoint);
+}
 
-    if (connectionInfo.endProc != nullptr)
-    {
-        auto* endEditor = board->findEditorForProcessor (connectionInfo.endProc);
-        jassert (endEditor != nullptr);
-
-        endPortLocation = CableViewPortLocationHelper::getPortLocation ({ endEditor, connectionInfo.endPort, true }).toFloat();
-        endColour = endEditor->getColour();
-        levelDB = connectionInfo.endProc->getInputLevelDB (connectionInfo.endPort);
-
-        drawCable (g, startPortLocation, endPortLocation);
-    }
-    else if (cableView.cableBeingDragged())
-    {
-        endColour = startColour;
-        drawCable (g, startPortLocation, cableView.getCableMousePosition());
-    }
+void Cable::resized()
+{
+    updateStartPoint (false);
+    updateEndPoint (false);
+    repaintIfNeeded (true);
 }

--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -121,6 +121,7 @@ void Cable::repaintIfNeeded (bool force)
         if (std::abs (levelDifference) > 2.0f && levelRange.contains (updatedLevelDB) && levelRange.contains (levelDB))
         {
             levelDB = updatedLevelDB;
+            cableThickness = getCableThickness();
             regeneratePath();
         }
     }

--- a/src/gui/pedalboard/cables/CableDrawingHelpers.cpp
+++ b/src/gui/pedalboard/cables/CableDrawingHelpers.cpp
@@ -4,20 +4,26 @@ namespace CableDrawingHelpers
 {
 using namespace CableConstants;
 
+#if JUCE_IOS
+constexpr float glowSizeFactor = 4.5f;
+#else
+constexpr float glowSizeFactor = 2.5f;
+#endif
+
+juce::Rectangle<float> getPortGlowBounds (juce::Point<int> location, float scaleFactor)
+{
+    const auto glowDim = (float) getPortDistanceLimit (scaleFactor) * glowSizeFactor;
+    auto glowBounds = (Rectangle (glowDim, glowDim)).withCentre (location.toFloat());
+
+    return glowBounds;
+}
+
 void drawCablePortGlow (Graphics& g, juce::Point<int> location, float scaleFactor)
 {
     Graphics::ScopedSaveState graphicsState (g);
     g.setColour (cableColour.darker (0.1f));
     g.setOpacity (0.65f);
 
-#if JUCE_IOS
-    constexpr float glowSizeFactor = 4.5f;
-#else
-    constexpr float glowSizeFactor = 2.5f;
-#endif
-
-    const auto glowDim = (float) getPortDistanceLimit (scaleFactor) * glowSizeFactor;
-    auto glowBounds = (Rectangle (glowDim, glowDim)).withCentre (location.toFloat());
-    g.fillEllipse (glowBounds);
+    g.fillEllipse (getPortGlowBounds (location, scaleFactor));
 }
 } // namespace CableDrawingHelpers

--- a/src/gui/pedalboard/cables/CableDrawingHelpers.h
+++ b/src/gui/pedalboard/cables/CableDrawingHelpers.h
@@ -5,7 +5,7 @@
 namespace CableConstants
 {
 const Colour cableColour (0xFFD0592C); // currently only used for "glow"
-constexpr float cableThickness = 5.0f;
+constexpr float minCableThickness = 5.0f;
 constexpr float portCircleThickness = 1.5f;
 
 constexpr int getPortDistanceLimit (float scaleFactor) { return int (20.0f * scaleFactor); }
@@ -16,5 +16,7 @@ constexpr float floorDB = -60.0f;
 
 namespace CableDrawingHelpers
 {
+juce::Rectangle<float> getPortGlowBounds (juce::Point<int> location, float scaleFactor);
+
 void drawCablePortGlow (Graphics& g, juce::Point<int> location, float scaleFactor);
 } // namespace CableDrawingHelpers

--- a/src/gui/pedalboard/cables/CableView.cpp
+++ b/src/gui/pedalboard/cables/CableView.cpp
@@ -153,11 +153,14 @@ int CableView::PathGeneratorTask::useTimeSlice()
     if (cableView.cableBeingDragged())
     {
         MessageManager::callAsync (
-            [&]
+            [safeCableView = Component::SafePointer (&cableView)]
             {
-                ScopedLock sl (cableView.cableMutex);
-                if (! cableView.cables.isEmpty())
-                    cableView.cables.getLast()->repaint();
+                if (auto* cv = safeCableView.getComponent())
+                {
+                    ScopedLock sl (cv->cableMutex);
+                    if (! cv->cables.isEmpty())
+                        cv->cables.getLast()->repaint();
+                }
             });
     }
 

--- a/src/gui/pedalboard/cables/CableView.cpp
+++ b/src/gui/pedalboard/cables/CableView.cpp
@@ -118,7 +118,7 @@ void CableView::timerCallback()
     using namespace CableDrawingHelpers;
 
     auto overClickablePort = mouseOverClickablePort();
-    
+
     // repaint port glow
     if (overClickablePort || mouseDraggingOverOutputPort())
     {

--- a/src/gui/pedalboard/cables/CableView.cpp
+++ b/src/gui/pedalboard/cables/CableView.cpp
@@ -4,7 +4,7 @@
 #include "CableViewConnectionHelper.h"
 #include "CableViewPortLocationHelper.h"
 
-CableView::CableView (BoardComponent* comp) : board (comp)
+CableView::CableView (BoardComponent* comp) : board (comp), pathTask (*this)
 {
     setInterceptsMouseClicks (false, true);
     startTimerHz (36);
@@ -15,39 +15,54 @@ CableView::CableView (BoardComponent* comp) : board (comp)
 
 CableView::~CableView() = default;
 
-void CableView::paint (Graphics& g)
+bool CableView::mouseOverClickablePort()
 {
-    using namespace CableDrawingHelpers;
-
+    const auto mousePos = Desktop::getMousePosition() - getScreenPosition();
+    nearestPort = portLocationHelper->getNearestPort (mousePos, board);
     if (nearestPort.editor != nullptr)
     {
         const bool isDraggingNearInputPort = nearestPort.isInput && isDraggingCable;
         const bool isNearConnectedInput = nearestPort.isInput && ! portLocationHelper->isInputPortConnected (nearestPort);
         if (! (isDraggingNearInputPort || isNearConnectedInput))
         {
-            auto startPortLocation = CableViewPortLocationHelper::getPortLocation (nearestPort);
-            drawCablePortGlow (g, startPortLocation, scaleFactor);
+            portToPaint = CableViewPortLocationHelper::getPortLocation (nearestPort);
+            return true;
         }
     }
 
+    return false;
+}
+
+bool CableView::mouseDraggingOverOutputPort()
+{
     if (cableMouse != nullptr)
     {
         auto mousePos = cableMouse->getPosition();
         const auto nearestInputPort = portLocationHelper->getNearestInputPort (mousePos, cables.getLast()->connectionInfo.startProc);
         if (nearestInputPort.editor != nullptr && nearestInputPort.isInput && ! portLocationHelper->isInputPortConnected (nearestInputPort))
         {
-            auto endPortLocation = CableViewPortLocationHelper::getPortLocation (nearestInputPort);
-            drawCablePortGlow (g, endPortLocation, scaleFactor);
+            portToPaint = CableViewPortLocationHelper::getPortLocation (nearestInputPort);
+            return true;
         }
+    }
+
+    return false;
+}
+
+void CableView::paint (Graphics& g)
+{
+    using namespace CableDrawingHelpers;
+
+    if (portGlow)
+    {
+        drawCablePortGlow (g, portToPaint, scaleFactor);
     }
 }
 
 void CableView::resized()
 {
     for (auto* cable : cables)
-    {
         cable->setBounds (getLocalBounds());
-    }
 }
 
 void CableView::mouseDown (const MouseEvent& e)
@@ -92,16 +107,35 @@ void CableView::mouseUp (const MouseEvent& e)
     if (isDraggingCable)
     {
         cableMouse.reset();
-        connectionHelper->releaseCable (e);
+        if (connectionHelper->releaseCable (e))
+            cables.getLast()->updateEndPoint();
         isDraggingCable = false;
     }
 }
 
 void CableView::timerCallback()
 {
-    const auto mousePos = Desktop::getMousePosition() - getScreenPosition();
-    nearestPort = portLocationHelper->getNearestPort (mousePos, board);
-    repaint();
+    using namespace CableDrawingHelpers;
+
+    auto overClickablePort = mouseOverClickablePort();
+    
+    // repaint port glow
+    if (overClickablePort || mouseDraggingOverOutputPort())
+    {
+        portGlow = true;
+        repaint (getPortGlowBounds (portToPaint, scaleFactor).toNearestInt());
+    }
+    else if (! overClickablePort && portGlow)
+    {
+        portGlow = false;
+        repaint (getPortGlowBounds (portToPaint, scaleFactor).toNearestInt());
+    }
+
+    for (auto* cable : cables)
+    {
+        cable->updateStartPoint();
+        cable->updateEndPoint();
+    }
 }
 
 void CableView::processorBeingAdded (BaseProcessor* newProc)
@@ -112,4 +146,24 @@ void CableView::processorBeingAdded (BaseProcessor* newProc)
 void CableView::processorBeingRemoved (const BaseProcessor* proc)
 {
     connectionHelper->processorBeingRemoved (proc);
+}
+
+int CableView::PathGeneratorTask::useTimeSlice()
+{
+    if (cableView.cableBeingDragged())
+    {
+        MessageManager::callAsync (
+            [&]
+            {
+                ScopedLock sl (cableView.cableMutex);
+                if (! cableView.cables.isEmpty())
+                    cableView.cables.getLast()->repaint();
+            });
+    }
+
+    ScopedLock sl (cableView.cableMutex);
+    for (auto* cable : cableView.cables)
+        cable->repaintIfNeeded();
+
+    return 28; // approx. 35 frames / second
 }

--- a/src/gui/pedalboard/cables/CableView.h
+++ b/src/gui/pedalboard/cables/CableView.h
@@ -34,7 +34,6 @@ public:
         bool isInput = false;
     };
 
-
 private:
     void timerCallback() override;
 
@@ -58,7 +57,7 @@ private:
     bool mouseDraggingOverOutputPort();
 
     CriticalSection cableMutex;
-    
+
     bool portGlow = false;
 
     struct PathGeneratorTask : juce::TimeSliceClient
@@ -71,10 +70,10 @@ private:
             if (! sharedTimeSliceThread->isThreadRunning())
                 sharedTimeSliceThread->startThread();
         }
-        
+
         ~PathGeneratorTask()
         {
-            sharedTimeSliceThread->removeTimeSliceClient(this);
+            sharedTimeSliceThread->removeTimeSliceClient (this);
         }
 
         int useTimeSlice() override;

--- a/src/gui/pedalboard/cables/CableViewConnectionHelper.h
+++ b/src/gui/pedalboard/cables/CableViewConnectionHelper.h
@@ -13,7 +13,7 @@ public:
 
     void addCableToView (Cable* cable);
     void createCable (const ConnectionInfo& connection);
-    void releaseCable (const MouseEvent& e);
+    bool releaseCable (const MouseEvent& e);
     void destroyCable (BaseProcessor* proc, int portIndex);
 
     void clickOnCable (PopupMenu& menu, PopupMenu::Options& options, Cable* clickedCable);

--- a/src/gui/utils/LevelMeterComponent.cpp
+++ b/src/gui/utils/LevelMeterComponent.cpp
@@ -1,5 +1,12 @@
 #include "LevelMeterComponent.h"
 
+namespace
+{
+constexpr auto maxDB = 6.0f;
+constexpr auto minDB = -45.0f;
+constexpr auto dBRange = maxDB - minDB;
+} // namespace
+
 LevelMeterComponent::LevelMeterComponent (const LevelDataType& levelData) : rmsLevels (levelData)
 {
     constexpr int timerHz = 24;
@@ -13,25 +20,25 @@ LevelMeterComponent::LevelMeterComponent (const LevelDataType& levelData) : rmsL
     startTimerHz (timerHz);
 }
 
+Rectangle<int> LevelMeterComponent::getMeterBounds() const
+{
+    return Rectangle { 35, getHeight() - 2 }.withCentre (getLocalBounds().getCentre());
+}
+
 void LevelMeterComponent::paint (Graphics& g)
 {
-    auto meterBounds = Rectangle { 35, getHeight() - 2 }.withCentre (getLocalBounds().getCentre());
+    auto meterBounds = getMeterBounds();
 
     g.setColour (Colours::black);
     g.fillRoundedRectangle (meterBounds.toFloat(), 4.0f);
 
     meterBounds.reduce (4, 5);
     const auto height = meterBounds.getHeight();
-    //    const auto meterMarkBounds = meterBounds.removeFromLeft (meterBounds.getWidth() / 3);
     const auto leftChBounds = meterBounds.removeFromLeft (meterBounds.getWidth() / 2).translated (-1, 0);
     const auto rightChBounds = meterBounds.translated (1, 0);
 
     auto getYForDB = [height] (float dB)
     {
-        constexpr auto maxDB = 6.0f;
-        constexpr auto minDB = -45.0f;
-        constexpr auto dBRange = maxDB - minDB;
-
         auto normLevel = jmin (jmax (dB - minDB, 0.0f) / dBRange, 1.0f);
         return int ((1.0f - normLevel) * (float) height);
     };
@@ -43,24 +50,22 @@ void LevelMeterComponent::paint (Graphics& g)
     const auto yPad = meterBounds.getY() / 2;
     g.fillRect (leftChBounds.withTop (getYForDB (dbLevels[0]) + yPad));
     g.fillRect (rightChBounds.withTop (getYForDB (dbLevels[1]) + yPad));
-
-    //    g.setFont (12.0f);
-    //    g.setColour (Colours::black);
-    //    for (auto dbLevel : { -45.0f, -30.0f, -15.0f, 0.0f })
-    //    {
-    //        auto y = (float) getYForDB (dbLevel);
-    //        auto right = (float) meterMarkBounds.getRight();
-    //        g.drawLine (right - 6.0f, y, right, y);
-    //
-    //        const auto labelBounds = meterMarkBounds.withHeight (20).withCentre (juce::Point { meterMarkBounds.getCentreX(), (int) y });
-    //        g.drawFittedText (String ((int) dbLevel), labelBounds, Justification::centred, 1);
-    //    }
 }
 
 void LevelMeterComponent::timerCallback()
 {
+    bool needsRepaint = false;
     for (int ch = 0; ch < 2; ++ch)
+    {
         dbLevels[ch] = Decibels::gainToDecibels (levelDetector[ch].processSample (rmsLevels[ch]));
 
-    repaint();
+        if (std::abs (dbLevels[ch] - dbLevelsPrev[ch]) > 0.5f && dbLevels[ch] > minDB && dbLevelsPrev[ch] > minDB)
+        {
+            dbLevelsPrev[ch] = dbLevels[ch];
+            needsRepaint = true;
+        }
+    }
+
+    if (needsRepaint)
+        repaint (getMeterBounds());
 }

--- a/src/gui/utils/LevelMeterComponent.h
+++ b/src/gui/utils/LevelMeterComponent.h
@@ -14,7 +14,10 @@ public:
     void timerCallback() final;
 
 private:
+    Rectangle<int> getMeterBounds() const;
+
     const LevelDataType& rmsLevels;
     std::array<float, 2> dbLevels {};
+    std::array<float, 2> dbLevelsPrev {};
     chowdsp::LevelDetector<float> levelDetector[2];
 };

--- a/src/processors/ProcessorStore.cpp
+++ b/src/processors/ProcessorStore.cpp
@@ -178,6 +178,21 @@ void createProcListFiltered (const ProcessorStore& store, PopupMenu& menu, int& 
     const auto addOnProcessorStore = std::make_unique<AddOnProcessorStore>();
 #endif
 
+    if (procToReplace != nullptr
+        && procToReplace->getNumInputs() == 1
+        && procToReplace->getNumOutputs() == 1)
+    {
+        PopupMenu::Item item;
+        item.itemID = ++menuID;
+        item.text = "Nothing";
+        item.action = [&store, procToReplace]
+        {
+            store.replaceProcessorCallback (nullptr, procToReplace);
+        };
+
+        menu.addItem (item);
+    }
+
     for (auto type : { Drive, Tone, Modulation, Utility, Other })
     {
         PopupMenu subMenu;


### PR DESCRIPTION
From Jatin:
- Redrawing cables makes all the module be redrawn as well
- Cable visualizations off -> no repainting
- Cable viz -> can we generate the paths on a separate thread (use shared Time Slice Thread like oscilloscopes)
- If level isn't changing -> no redrawing cables