### PR TITLE
Extend Cable Redraw Width

### DIFF
--- a/src/gui/pedalboard/cables/Cable.cpp
+++ b/src/gui/pedalboard/cables/Cable.cpp
@@ -104,8 +104,8 @@ void Cable::repaintIfNeeded (bool force)
         MessageManager::callAsync (
             [safeComp = Component::SafePointer (this), cableBounds]
             {
-            if (auto* comp = safeComp.getComponent())
-                comp->repaint (cableBounds);
+                if (auto* comp = safeComp.getComponent())
+                    comp->repaint (cableBounds);
             });
     };
 


### PR DESCRIPTION
![Screen Shot 2022-11-07 at 11 07 54 AM](https://user-images.githubusercontent.com/43660096/200396277-378d78a4-8310-4409-8e3e-9eb4d7559536.png)

Noticed that the cable bounds were missing some of the outer edges of the cable, and when the cable glow/expand happened these outer edges weren't getting drawn like the rest of the cable.