### PR TITLE
Processor Port Handling 

### DIFF
--- a/src/gui/pedalboard/editors/Port.cpp
+++ b/src/gui/pedalboard/editors/Port.cpp
@@ -1,5 +1,6 @@
 #include "Port.h"
 #include "../cables/CableDrawingHelpers.h"
+#include "../src/processors/BaseProcessor.h"
 
 Port::Port (const Colour& processorColour, const PortType type) : Component ("Port"),
                                                                   procColour (processorColour),

--- a/src/gui/pedalboard/editors/Port.h
+++ b/src/gui/pedalboard/editors/Port.h
@@ -2,11 +2,7 @@
 
 #include <pch.h>
 
-enum class PortType
-{
-    audio = 0,
-    modulation,
-};
+enum class PortType;
 
 class Port : public Component
 {
@@ -25,7 +21,7 @@ private:
     bool isConnected = false;
 
     const Colour& procColour;
-    const PortType portType = PortType::audio;
+    const PortType portType;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Port)
 };

--- a/src/processors/BaseProcessor.cpp
+++ b/src/processors/BaseProcessor.cpp
@@ -4,22 +4,17 @@
 
 BaseProcessor::BaseProcessor (const String& name,
                               ParamLayout params,
-                              UndoManager* um,
-                              int nInputs,
-                              int nOutputs) : JuceProcWrapper (name),
-                                              vts (*this, um, Identifier ("Parameters"), std::move (params)),
-                                              numInputs (nInputs),
-                                              numOutputs (nOutputs)
+                              UndoManager* um) : BaseProcessor (
+    name,
+    std::move (params),
+    BasicInputPort {},
+    BasicOutputPort {},
+    um,
+    [] (auto)
+    { return PortType::audio; },
+    [] (auto)
+    { return PortType::audio; })
 {
-    onOffParam = vts.getRawParameterValue ("on_off");
-
-    outputBuffers.resize (jmax (1, numOutputs));
-    outputBuffers.fill (nullptr);
-    outputConnections.resize (numOutputs);
-
-    inputBuffers.resize (numInputs);
-    inputsConnected.resize (0);
-    portMagnitudes.resize (numInputs);
 }
 
 BaseProcessor::~BaseProcessor() = default;

--- a/src/processors/BaseProcessor.cpp
+++ b/src/processors/BaseProcessor.cpp
@@ -1,6 +1,6 @@
 #include "BaseProcessor.h"
 #include "gui/pedalboard/editors/ProcessorEditor.h"
-#include "processors/netlist_helpers/NetlistViewer.h"
+#include "netlist_helpers/NetlistViewer.h"
 
 BaseProcessor::BaseProcessor (const String& name,
                               ParamLayout params,
@@ -15,6 +15,29 @@ BaseProcessor::BaseProcessor (const String& name,
     [] (auto)
     { return PortType::audio; })
 {
+}
+
+BaseProcessor::BaseProcessor (const String& name,
+                              ParamLayout&& params,
+                              base_processor_detail::PortTypesVector&& inputPorts,
+                              base_processor_detail::PortTypesVector&& outputPorts,
+                              UndoManager* um)
+    : JuceProcWrapper (name),
+      vts (*this, um, Identifier ("Parameters"), std::move (params)),
+      numInputs ((int) inputPorts.size()),
+      numOutputs ((int) outputPorts.size()),
+      inputPortTypes (std::move (inputPorts)),
+      outputPortTypes (std::move (outputPorts))
+{
+    onOffParam = vts.getRawParameterValue ("on_off");
+
+    outputBuffers.resize (jmax (1, numOutputs));
+    outputBuffers.fill (nullptr);
+    outputConnections.resize (numOutputs);
+
+    inputBuffers.resize (numInputs);
+    inputsConnected.resize (0);
+    portMagnitudes.resize (numInputs);
 }
 
 BaseProcessor::~BaseProcessor() = default;

--- a/src/processors/BaseProcessor.h
+++ b/src/processors/BaseProcessor.h
@@ -95,14 +95,6 @@ public:
                                                                                          inputPortTypes (base_processor_detail::initialisePortTypes<InputPort> (inputPortMapper)),
                                                                                          outputPortTypes (base_processor_detail::initialisePortTypes<OutputPort> (outputPortMapper))
     {
-        std::cout << "Creating processor: " << name << std::endl;
-        std::cout << "With input ports: " << std::endl;
-        for (size_t i = 0; i < inputPortTypes.size(); ++i)
-            std::cout << "    " << magic_enum::enum_name ((InputPort) i) << " (" << magic_enum::enum_name (inputPortTypes[i]) << ")" << std::endl;
-        std::cout << "With output ports: " << std::endl;
-        for (size_t i = 0; i < outputPortTypes.size(); ++i)
-            std::cout << "    " << magic_enum::enum_name ((OutputPort) i) << " (" << magic_enum::enum_name (outputPortTypes[i]) << ")" << std::endl;
-
         onOffParam = vts.getRawParameterValue ("on_off");
 
         outputBuffers.resize (jmax (1, numOutputs));

--- a/src/processors/modulation/Chorus.cpp
+++ b/src/processors/modulation/Chorus.cpp
@@ -15,11 +15,24 @@ constexpr float delay2Ms = 0.2f;
 const String delayTypeTag = "delay_type";
 } // namespace
 
-Chorus::Chorus (UndoManager* um) : BaseProcessor ("Chorus",
-                                                  createParameterLayout(),
-                                                  um,
-                                                  magic_enum::enum_count<InputPort>(),
-                                                  magic_enum::enum_count<OutputPort>())
+Chorus::Chorus (UndoManager* um) : BaseProcessor (
+    "Chorus",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateParam, vts, "rate");

--- a/src/processors/modulation/Flanger.cpp
+++ b/src/processors/modulation/Flanger.cpp
@@ -11,11 +11,24 @@ constexpr float delayMs = 0.001f;
 const String delayTypeTag = "delay_type";
 } // namespace
 
-Flanger::Flanger (UndoManager* um) : BaseProcessor ("Flanger",
-                                                    createParameterLayout(),
-                                                    um,
-                                                    magic_enum::enum_count<InputPort>(),
-                                                    magic_enum::enum_count<OutputPort>())
+Flanger::Flanger (UndoManager* um) : BaseProcessor (
+    "Flanger",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateParam, vts, "rate");

--- a/src/processors/modulation/Panner.cpp
+++ b/src/processors/modulation/Panner.cpp
@@ -15,11 +15,24 @@ const String panModeTag = "pan_mode";
 const String stereoModeTag = "stereo_mode";
 } // namespace
 
-Panner::Panner (UndoManager* um) : BaseProcessor ("Panner",
-                                                  createParameterLayout(),
-                                                  um,
-                                                  magic_enum::enum_count<InputPort>(),
-                                                  magic_enum::enum_count<OutputPort>())
+Panner::Panner (UndoManager* um) : BaseProcessor (
+    "Panner",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (mainPan, vts, mainPanTag);

--- a/src/processors/modulation/Rotary.cpp
+++ b/src/processors/modulation/Rotary.cpp
@@ -7,11 +7,24 @@ namespace
 const String stereoTag = "stereo";
 }
 
-Rotary::Rotary (UndoManager* um) : BaseProcessor ("Rotary",
-                                                  createParameterLayout(),
-                                                  um,
-                                                  magic_enum::enum_count<InputPort>(),
-                                                  magic_enum::enum_count<OutputPort>())
+Rotary::Rotary (UndoManager* um) : BaseProcessor (
+    "Rotary",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     chowdsp::ParamUtils::loadParameterPointer (rateHzParam, vts, "rate");
     chowdsp::ParamUtils::loadParameterPointer (stereoParam, vts, stereoTag);

--- a/src/processors/modulation/Tremolo.cpp
+++ b/src/processors/modulation/Tremolo.cpp
@@ -25,11 +25,24 @@ const String v1WaveTag = "v1_wave";
 
 } // namespace
 
-Tremolo::Tremolo (UndoManager* um) : BaseProcessor ("Tremolo",
-                                                    createParameterLayout(),
-                                                    um,
-                                                    magic_enum::enum_count<InputPort>(),
-                                                    magic_enum::enum_count<OutputPort>())
+Tremolo::Tremolo (UndoManager* um) : BaseProcessor (
+    "Tremolo",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateParam, vts, "rate");

--- a/src/processors/modulation/phaser/Phaser4.cpp
+++ b/src/processors/modulation/phaser/Phaser4.cpp
@@ -12,11 +12,24 @@ const String fbStageTag = "fb_stage";
 const String stereoTag = "stereo";
 } // namespace
 
-Phaser4::Phaser4 (UndoManager* um) : BaseProcessor ("Phaser4",
-                                                    createParameterLayout(),
-                                                    um,
-                                                    magic_enum::enum_count<InputPort>(),
-                                                    magic_enum::enum_count<OutputPort>())
+Phaser4::Phaser4 (UndoManager* um) : BaseProcessor (
+    "Phaser4",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateHzParam, vts, rateTag);

--- a/src/processors/modulation/phaser/Phaser8.cpp
+++ b/src/processors/modulation/phaser/Phaser8.cpp
@@ -10,11 +10,24 @@ const String feedbackTag = "feedback";
 const String modulationTag = "modulation";
 } // namespace
 
-Phaser8::Phaser8 (UndoManager* um) : BaseProcessor ("Phaser8",
-                                                    createParameterLayout(),
-                                                    um,
-                                                    magic_enum::enum_count<InputPort>(),
-                                                    magic_enum::enum_count<OutputPort>())
+Phaser8::Phaser8 (UndoManager* um) : BaseProcessor (
+    "Phaser8",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateHzParam, vts, rateTag);

--- a/src/processors/modulation/scanner_vibrato/ScannerVibrato.cpp
+++ b/src/processors/modulation/scanner_vibrato/ScannerVibrato.cpp
@@ -23,11 +23,24 @@ float ramp_down (float x, int off)
 }
 } // namespace
 
-ScannerVibrato::ScannerVibrato (UndoManager* um) : BaseProcessor ("Scanner Vibrato",
-                                                                  createParameterLayout(),
-                                                                  um,
-                                                                  magic_enum::enum_count<InputPort>(),
-                                                                  magic_enum::enum_count<OutputPort>())
+ScannerVibrato::ScannerVibrato (UndoManager* um) : BaseProcessor (
+    "Scanner Vibrato",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (rateHzParam, vts, rateTag);

--- a/src/processors/modulation/uni_vibe/UniVibe.cpp
+++ b/src/processors/modulation/uni_vibe/UniVibe.cpp
@@ -11,11 +11,24 @@ const String stereoTag = "stereo";
 const String mixTag = "mix";
 } // namespace
 
-UniVibe::UniVibe (UndoManager* um) : BaseProcessor ("Solo-Vibe",
-                                                    createParameterLayout(),
-                                                    um,
-                                                    magic_enum::enum_count<InputPort>(),
-                                                    magic_enum::enum_count<OutputPort>())
+UniVibe::UniVibe (UndoManager* um) : BaseProcessor (
+    "Solo-Vibe",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::ModulationInput)
+            return PortType::modulation;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::ModulationOutput)
+            return PortType::modulation;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     speedParamSmooth.setParameterHandle (getParameterPointer<chowdsp::FloatParameter*> (vts, speedTag));

--- a/src/processors/other/Compressor.cpp
+++ b/src/processors/other/Compressor.cpp
@@ -69,7 +69,24 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GainComputer)
 };
 
-Compressor::Compressor (UndoManager* um) : BaseProcessor ("Compressor", createParameterLayout(), um)
+Compressor::Compressor (UndoManager* um) : BaseProcessor (
+    "Compressor",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::LevelInput)
+            return PortType::level;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::LevelOutput)
+            return PortType::level;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (threshDBParam, vts, "thresh");

--- a/src/processors/other/Compressor.h
+++ b/src/processors/other/Compressor.h
@@ -30,5 +30,17 @@ private:
 
     dsp::Gain<float> makeupGain;
 
+    enum InputPort
+    {
+        AudioInput = 0,
+        LevelInput,
+    };
+
+    enum OutputPort
+    {
+        AudioOutput = 0,
+        LevelOutput,
+    };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Compressor)
 };

--- a/src/processors/other/EnvelopeFilter.cpp
+++ b/src/processors/other/EnvelopeFilter.cpp
@@ -20,7 +20,24 @@ const String directControlTag = "direct_control";
 const String freqModTag = "freq_mod";
 } // namespace
 
-EnvelopeFilter::EnvelopeFilter (UndoManager* um) : BaseProcessor ("Envelope Filter", createParameterLayout(), um)
+EnvelopeFilter::EnvelopeFilter (UndoManager* um) : BaseProcessor (
+    "Envelope Filter",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::LevelInput)
+            return PortType::level;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::LevelOutput)
+            return PortType::level;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (freqParam, vts, "freq");

--- a/src/processors/other/EnvelopeFilter.h
+++ b/src/processors/other/EnvelopeFilter.h
@@ -31,5 +31,17 @@ private:
     AudioBuffer<float> levelBuffer;
     chowdsp::LevelDetector<float> level;
 
+    enum InputPort
+    {
+        AudioInput = 0,
+        LevelInput,
+    };
+
+    enum OutputPort
+    {
+        AudioOutput = 0,
+        LevelOutput,
+    };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (EnvelopeFilter)
 };

--- a/src/processors/other/Gate.cpp
+++ b/src/processors/other/Gate.cpp
@@ -93,7 +93,24 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GateEnvelope)
 };
 
-Gate::Gate (UndoManager* um) : BaseProcessor ("Gate", createParameterLayout(), um)
+Gate::Gate (UndoManager* um) : BaseProcessor (
+    "Gate",
+    createParameterLayout(),
+    InputPort {},
+    OutputPort {},
+    um,
+    [] (InputPort port)
+    {
+        if (port == InputPort::LevelInput)
+            return PortType::level;
+        return PortType::audio;
+    },
+    [] (OutputPort port)
+    {
+        if (port == OutputPort::LevelOutput)
+            return PortType::level;
+        return PortType::audio;
+    })
 {
     using namespace ParameterHelpers;
     loadParameterPointer (threshDBParam, vts, "thresh");

--- a/src/processors/other/Gate.h
+++ b/src/processors/other/Gate.h
@@ -28,5 +28,17 @@ private:
 
     dsp::Gain<float> makeupGain;
 
+    enum InputPort
+    {
+        AudioInput = 0,
+        LevelInput,
+    };
+
+    enum OutputPort
+    {
+        AudioOutput = 0,
+        LevelOutput,
+    };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Gate)
 };

--- a/src/processors/utility/FreqBandSplitter.cpp
+++ b/src/processors/utility/FreqBandSplitter.cpp
@@ -3,8 +3,8 @@
 
 FreqBandSplitter::FreqBandSplitter (UndoManager* um) : BaseProcessor ("Frequency Splitter",
                                                                       createParameterLayout(),
-                                                                      BasicInputPort{},
-                                                                      OutputPort{},
+                                                                      BasicInputPort {},
+                                                                      OutputPort {},
                                                                       um)
 {
     using namespace ParameterHelpers;

--- a/src/processors/utility/FreqBandSplitter.cpp
+++ b/src/processors/utility/FreqBandSplitter.cpp
@@ -1,7 +1,11 @@
 #include "FreqBandSplitter.h"
 #include "../ParameterHelpers.h"
 
-FreqBandSplitter::FreqBandSplitter (UndoManager* um) : BaseProcessor ("Frequency Splitter", createParameterLayout(), um, 1, numOuts)
+FreqBandSplitter::FreqBandSplitter (UndoManager* um) : BaseProcessor ("Frequency Splitter",
+                                                                      createParameterLayout(),
+                                                                      BasicInputPort{},
+                                                                      OutputPort{},
+                                                                      um)
 {
     using namespace ParameterHelpers;
     loadParameterPointer (crossLowParam, vts, "cross_low");

--- a/src/processors/utility/InputProcessor.cpp
+++ b/src/processors/utility/InputProcessor.cpp
@@ -3,8 +3,8 @@
 
 InputProcessor::InputProcessor (UndoManager* um) : BaseProcessor ("Input",
                                                                   createParameterLayout(),
-                                                                  NullPort{},
-                                                                  BasicOutputPort{},
+                                                                  NullPort {},
+                                                                  BasicOutputPort {},
                                                                   um)
 {
     uiOptions.backgroundColour = Colours::orange;

--- a/src/processors/utility/InputProcessor.cpp
+++ b/src/processors/utility/InputProcessor.cpp
@@ -1,7 +1,11 @@
 #include "InputProcessor.h"
 #include "../ParameterHelpers.h"
 
-InputProcessor::InputProcessor (UndoManager* um) : BaseProcessor ("Input", createParameterLayout(), um, 0, 1)
+InputProcessor::InputProcessor (UndoManager* um) : BaseProcessor ("Input",
+                                                                  createParameterLayout(),
+                                                                  NullPort{},
+                                                                  BasicOutputPort{},
+                                                                  um)
 {
     uiOptions.backgroundColour = Colours::orange;
 }

--- a/src/processors/utility/Mixer.cpp
+++ b/src/processors/utility/Mixer.cpp
@@ -3,8 +3,8 @@
 
 Mixer::Mixer (UndoManager* um) : BaseProcessor ("Mixer",
                                                 createParameterLayout(),
-                                                InputPort{},
-                                                BasicOutputPort{},
+                                                InputPort {},
+                                                BasicOutputPort {},
                                                 um)
 {
     for (int i = 0; i < numIns; ++i)

--- a/src/processors/utility/Mixer.cpp
+++ b/src/processors/utility/Mixer.cpp
@@ -3,9 +3,9 @@
 
 Mixer::Mixer (UndoManager* um) : BaseProcessor ("Mixer",
                                                 createParameterLayout(),
-                                                um,
-                                                numIns,
-                                                1)
+                                                InputPort{},
+                                                BasicOutputPort{},
+                                                um)
 {
     for (int i = 0; i < numIns; ++i)
         chowdsp::ParamUtils::loadParameterPointer (gainDBParams[i], vts, "gain" + String (i));

--- a/src/processors/utility/Oscilloscope.cpp
+++ b/src/processors/utility/Oscilloscope.cpp
@@ -6,7 +6,11 @@ namespace
 constexpr int scopeFps = 30;
 }
 
-Oscilloscope::Oscilloscope (UndoManager* um) : BaseProcessor ("Oscilloscope", createParameterLayout(), um, 1, 0)
+Oscilloscope::Oscilloscope (UndoManager* um) : BaseProcessor ("Oscilloscope",
+                                                              createParameterLayout(),
+                                                              BasicInputPort{},
+                                                              NullPort{},
+                                                              um)
 {
     uiOptions.backgroundColour = Colours::silver.brighter (0.2f);
     uiOptions.powerColour = Colours::red;

--- a/src/processors/utility/Oscilloscope.cpp
+++ b/src/processors/utility/Oscilloscope.cpp
@@ -8,8 +8,8 @@ constexpr int scopeFps = 30;
 
 Oscilloscope::Oscilloscope (UndoManager* um) : BaseProcessor ("Oscilloscope",
                                                               createParameterLayout(),
-                                                              BasicInputPort{},
-                                                              NullPort{},
+                                                              BasicInputPort {},
+                                                              NullPort {},
                                                               um)
 {
     uiOptions.backgroundColour = Colours::silver.brighter (0.2f);

--- a/src/processors/utility/OutputProcessor.cpp
+++ b/src/processors/utility/OutputProcessor.cpp
@@ -3,8 +3,8 @@
 
 OutputProcessor::OutputProcessor (UndoManager* um) : BaseProcessor ("Output",
                                                                     createParameterLayout(),
-                                                                    BasicInputPort{},
-                                                                    NullPort{},
+                                                                    BasicInputPort {},
+                                                                    NullPort {},
                                                                     um)
 {
     uiOptions.backgroundColour = Colours::lightskyblue;

--- a/src/processors/utility/OutputProcessor.cpp
+++ b/src/processors/utility/OutputProcessor.cpp
@@ -1,7 +1,11 @@
 #include "OutputProcessor.h"
 #include "../ParameterHelpers.h"
 
-OutputProcessor::OutputProcessor (UndoManager* um) : BaseProcessor ("Output", createParameterLayout(), um, 1, 0)
+OutputProcessor::OutputProcessor (UndoManager* um) : BaseProcessor ("Output",
+                                                                    createParameterLayout(),
+                                                                    BasicInputPort{},
+                                                                    NullPort{},
+                                                                    um)
 {
     uiOptions.backgroundColour = Colours::lightskyblue;
 }

--- a/src/processors/utility/StereoMerger.cpp
+++ b/src/processors/utility/StereoMerger.cpp
@@ -3,8 +3,8 @@
 
 StereoMerger::StereoMerger (UndoManager* um) : BaseProcessor ("Stereo Merger",
                                                               createParameterLayout(),
-                                                              InputPort{},
-                                                              BasicOutputPort{},
+                                                              InputPort {},
+                                                              BasicOutputPort {},
                                                               um)
 {
     modeParam = vts.getRawParameterValue ("mode");

--- a/src/processors/utility/StereoMerger.cpp
+++ b/src/processors/utility/StereoMerger.cpp
@@ -3,9 +3,9 @@
 
 StereoMerger::StereoMerger (UndoManager* um) : BaseProcessor ("Stereo Merger",
                                                               createParameterLayout(),
-                                                              um,
-                                                              magic_enum::enum_count<InputPort>(),
-                                                              1)
+                                                              InputPort{},
+                                                              BasicOutputPort{},
+                                                              um)
 {
     modeParam = vts.getRawParameterValue ("mode");
 

--- a/src/processors/utility/StereoSplitter.cpp
+++ b/src/processors/utility/StereoSplitter.cpp
@@ -3,8 +3,8 @@
 
 StereoSplitter::StereoSplitter (UndoManager* um) : BaseProcessor ("Stereo Splitter",
                                                                   createParameterLayout(),
-                                                                  BasicInputPort{},
-                                                                  OutputPort{},
+                                                                  BasicInputPort {},
+                                                                  OutputPort {},
                                                                   um)
 {
     modeParam = vts.getRawParameterValue ("mode");

--- a/src/processors/utility/StereoSplitter.cpp
+++ b/src/processors/utility/StereoSplitter.cpp
@@ -1,7 +1,11 @@
 #include "StereoSplitter.h"
 #include "../ParameterHelpers.h"
 
-StereoSplitter::StereoSplitter (UndoManager* um) : BaseProcessor ("Stereo Splitter", createParameterLayout(), um, 1, numOuts)
+StereoSplitter::StereoSplitter (UndoManager* um) : BaseProcessor ("Stereo Splitter",
+                                                                  createParameterLayout(),
+                                                                  BasicInputPort{},
+                                                                  OutputPort{},
+                                                                  um)
 {
     modeParam = vts.getRawParameterValue ("mode");
 

--- a/src/processors/utility/Tuner.cpp
+++ b/src/processors/utility/Tuner.cpp
@@ -8,8 +8,8 @@ constexpr int tunerRefreshHz = 24;
 
 Tuner::Tuner (UndoManager* um) : BaseProcessor ("Tuner",
                                                 createParameterLayout(),
-                                                BasicInputPort{},
-                                                NullPort{},
+                                                BasicInputPort {},
+                                                NullPort {},
                                                 um)
 {
     uiOptions.backgroundColour = Colours::silver.brighter (0.2f);

--- a/src/processors/utility/Tuner.cpp
+++ b/src/processors/utility/Tuner.cpp
@@ -6,7 +6,11 @@ namespace
 constexpr int tunerRefreshHz = 24;
 }
 
-Tuner::Tuner (UndoManager* um) : BaseProcessor ("Tuner", createParameterLayout(), um, 1, 0)
+Tuner::Tuner (UndoManager* um) : BaseProcessor ("Tuner",
+                                                createParameterLayout(),
+                                                BasicInputPort{},
+                                                NullPort{},
+                                                um)
 {
     uiOptions.backgroundColour = Colours::silver.brighter (0.2f);
     uiOptions.powerColour = Colours::red;


### PR DESCRIPTION
New templated constructor for BaseProcessor allows const PortType vectors inputPortTypes and outputPortTypes to be initialised at the time of instantiation based on the InputPort and OutputPort emuns of their derived processors and specified inputPortMapper and outputPortMapper. A second deligating constructor creates derived processors without custom mapping requirements and initialises the BaseProcessors const PortType vectors to basic audio I/O.

<img width="1008" alt="Screenshot 2023-06-23 at 14 36 01" src="https://github.com/Chowdhury-DSP/BYOD/assets/40403174/4fe3dc4e-0867-4cb7-9b1a-2c05d9b40633">
<img width="316" alt="Screenshot 2023-06-23 at 14 38 37" src="https://github.com/Chowdhury-DSP/BYOD/assets/40403174/790c96c3-6302-4f4e-b440-f03b268faff4">
